### PR TITLE
Update and fix the Hello World tutorial

### DIFF
--- a/01-hello-world.md
+++ b/01-hello-world.md
@@ -20,6 +20,14 @@ gpui = { git = "https://github.com/zed-industries/zed" }
 
 Run `cargo build` to make sure that you are able to build the dependencies. If you're having problems (as I did), refer back to the [installation instructions](00-prerequisites.md#installation).
 
+## Import GPUI
+
+Create a new main.rs file and import gpui:
+
+```rs
+use gpui::*;
+```
+
 ## View
 
 To begin we need to define how we want to present the greeting to Mick Jagger. This is done by defining a [view](dictionary.md#view). A _view_ is the simplest [element](dictionary.md#element) we can use to [render](dictionary.md#render) UI in gpui. It is made up of two parts: (1) data that we will show (i.e., the [state](dictionary.md#state)), (2) the way we present (or [render](dictionary.md#render)) that data to a UI.

--- a/01-hello-world.md
+++ b/01-hello-world.md
@@ -53,7 +53,7 @@ Now that the data, or [state](dictionary.md#state) we want to show is defined, i
 
 ```rs
 impl Render for Person {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()
             .bg(rgb(0x333333))
@@ -79,9 +79,9 @@ We do this inside of the `main` function:
 
 ```rs
 fn main() {
-    App::new().run(|cx: &mut AppContext| {
-        cx.open_window(WindowOptions::default(), |cx| {
-            cx.new_view(|_cx| Person {
+    Application::new().run(|cx: &mut App| {
+        cx.open_window(WindowOptions::default(), |_, cx| {
+            cx.new(|_| Person {
                 first_name: "Mick".into(),
                 last_name: "Jagger".into(),
             })

--- a/01-hello-world.md
+++ b/01-hello-world.md
@@ -10,7 +10,7 @@ Instead of saying hi to _everyone_, here we're going to say hello to a famous ro
 
 ## Crate
 
-Create a new crate with `cargo new` and add gpui to your `Cargo.toml` file as a dependency:
+Create a new crate with `cargo init` and add gpui to your `Cargo.toml` file as a dependency:
 
 To use gpui, add a reference to it in the `Cargo.toml` file:
 

--- a/crates/hello_world/src/main.rs
+++ b/crates/hello_world/src/main.rs
@@ -6,7 +6,7 @@ struct Person {
 }
 
 impl Render for Person {
-    fn render(&mut self, _cx: &mut ViewContext<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()
             .bg(rgb(0x333333))
@@ -20,9 +20,9 @@ impl Render for Person {
 }
 
 fn main() {
-    App::new().run(|cx: &mut AppContext| {
-        cx.open_window(WindowOptions::default(), |cx| {
-            cx.new_view(|_cx| Person {
+    Application::new().run(|cx: &mut App| {
+        cx.open_window(WindowOptions::default(), |_, cx| {
+            cx.new(|_| Person {
                 first_name: "Mick".into(),
                 last_name: "Jagger".into(),
             })


### PR DESCRIPTION
The Hello World tutorial is broken due to changes in teh GPUI API, this PR fixes these changes and makes a couple of minor improvements to the tutorial:

* Add instructions to import gpui
* Recommend `cargo init` instead of `cargo new`, since it doesn't require any further arguments
* Update the syntax in the Hello World tutorial to current GPUI APIs
  * In particular, switch from `App` and `AppContext` to `Application` and `App` in
the `main()` method, and add the `_window` argument to the `Render`
implementation

This PR fixes [#3 Fix errors at 01-hello-world.md](https://github.com/hedge-ops/gpui-tutorial/issues/3)